### PR TITLE
Add defaultValue property to TouchUIDialogFieldOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="https://teclead.de/assets/custom_img/teclead_black.svg"
      alt="Teclead Logo"
      style="float: right; width:250px" />
+
 # AEM Dialog Generator
 
 This project contains the Custom Dialog Generator for AEM. The Library provides the creating of all necessary AEM Files (XML, HTML) to create an AEM component
@@ -18,9 +19,9 @@ Building the dialogues can then be executed by running npm run build:dialogues
 
 ## API
 
-The following example shows a *.dialog.ts file with the necessary configuration for the creating of an AEM component. 
+The following example shows a \*.dialog.ts file with the necessary configuration for the creating of an AEM component.
 
-******
+---
 
 ### Full Example
 
@@ -108,10 +109,10 @@ const tabs: TouchUIDialogTab[] = [
 ]
 ```
 
-The sightlyTemplate variable is referencing the HTMl-Template that is used to build the AEM component.  It is mandatory to create this reference on a component Level.
+The sightlyTemplate variable is referencing the HTMl-Template that is used to build the AEM component. It is mandatory to create this reference on a component Level.
 
 ```typescript
-const sightlyTemplate = "<h1>my custom template...</h1>"
+const sightlyTemplate = "<h1>my custom template...</h1>";
 ```
 
 The exampleTouchUiDialog: AEMTouchUIDialog variable describes the configuration of the AEM component. It holds the reference to the sightlyTemplate, the component name, the component group, the component description, tabs and the component path (destination path) as required inputs and a couple of optional properties than can be configured. For more Information check out the Interfaces.
@@ -119,40 +120,61 @@ The exampleTouchUiDialog: AEMTouchUIDialog variable describes the configuration 
 ```typescript
 export const exampleTouchUIDialog: AEMTouchUIDialog = {
   sightlyTemplate: sightlyTemplate,
-  componentName: 'MyTestComponent',
-  componentGroup: 'MyTestGroup',
-  componentDescription: 'MyTestComponentDescription',
-  componentPath: './src/__tests___/results/touchUI',
-  tabs: tabs
+  componentName: "MyTestComponent",
+  componentGroup: "MyTestGroup",
+  componentDescription: "MyTestComponentDescription",
+  componentPath: "./src/__tests___/results/touchUI",
+  tabs: tabs,
 };
 ```
 
 ## Full example for a simple component
-```typescript
-import { AEMTouchUIDialog, TouchUIField } from '@teclead/aem-generator/models';
-import {
-  TouchUIXMLGenerator
-} from '@teclead/aem-generator';
-import { COMPONENTPATH, COMPONENT_GROUP, REACT_TEMPLATE } from '../Commons/commons';
 
-const dropDownOptions = [{ value: 'val1', name: 'Label 1' }, { value: 'val2', name: 'Label 2' }];
+```typescript
+import { AEMTouchUIDialog, TouchUIField } from "@teclead/aem-generator/models";
+import { TouchUIXMLGenerator } from "@teclead/aem-generator";
+import {
+  COMPONENTPATH,
+  COMPONENT_GROUP,
+  REACT_TEMPLATE,
+} from "../Commons/commons";
+
+const dropDownOptions = [
+  { value: "val1", name: "Label 1" },
+  { value: "val2", name: "Label 2" },
+];
 
 export const ctaDialog: AEMTouchUIDialog = {
-  componentPath: COMPONENTPATH + 'ctaReact',
+  componentPath: COMPONENTPATH + "ctaReact",
   sightlyTemplate: REACT_TEMPLATE,
-  componentName: 'Button-React',
+  componentName: "Button-React",
   componentGroup: COMPONENT_GROUP,
-  tabs: [{
-    title: 'My first Tab',
-    fields: [
-      { label: 'Text field', databaseName: 'text', type: TouchUIField.Text },
-      { label: 'Text Area', databaseName: 'textArea', type: TouchUIField.TextArea },
-      { label: 'Dropdown field', databaseName: 'dropdown', type: TouchUIField.Dropwdown, options: dropDownOptions },
-      { label: 'Pathfield', databaseName: 'path', type: TouchUIField.Path, },
-      { label: 'Checkbox', databaseName: 'check', type: TouchUIField.Checkbox, },
-      { label: 'Image', databaseName: 'img', type: TouchUIField.Imagefield, }
-    ]
-  }]
+  tabs: [
+    {
+      title: "My first Tab",
+      fields: [
+        { label: "Text field", databaseName: "text", type: TouchUIField.Text },
+        {
+          label: "Text Area",
+          databaseName: "textArea",
+          type: TouchUIField.TextArea,
+        },
+        {
+          label: "Dropdown field",
+          databaseName: "dropdown",
+          type: TouchUIField.Dropdown,
+          options: dropDownOptions,
+        },
+        { label: "Pathfield", databaseName: "path", type: TouchUIField.Path },
+        {
+          label: "Checkbox",
+          databaseName: "check",
+          type: TouchUIField.Checkbox,
+        },
+        { label: "Image", databaseName: "img", type: TouchUIField.Imagefield },
+      ],
+    },
+  ],
 };
 
 new TouchUIXMLGenerator(ctaDialog).writeFilesToAEM(); // will write the files when npm build:dialogues is called
@@ -180,4 +202,5 @@ Important notice: Pull requests that are opened while they're still being worked
 Collapse
 
 ## License
+
 [MIT](https://teclead.de/#contact)

--- a/src/__tests___/__snapshots__/xmlTouchUIGenerator.test.ts.snap
+++ b/src/__tests___/__snapshots__/xmlTouchUIGenerator.test.ts.snap
@@ -116,7 +116,7 @@ exports[`xml generator for touch ui aem dialogs should print the touchUI dialog 
 <element_5
     jcr:primaryType=\\"nt:unstructured\\"
     sling:resourceType=\\"granite/ui/components/coral/foundation/form/select\\"
-    name=\\"./dropdown\\" fieldLabel=\\"Mein Dropwdown\\"   fieldDescription=\\"Meine Beschreibung für Dropwdown\\" >
+    name=\\"./dropdown\\" fieldLabel=\\"Mein Dropdown\\"   fieldDescription=\\"Meine Beschreibung für Dropdown\\" >
     <items jcr:primaryType=\\"nt:unstructured\\">
         <option_0 jcr:primaryType=\\"nt:unstructured\\" value=\\"1\\" text=\\"Name 1\\"/><option_1 jcr:primaryType=\\"nt:unstructured\\" value=\\"2\\" text=\\"Name 2\\"/><option_2 jcr:primaryType=\\"nt:unstructured\\" value=\\"3\\" text=\\"Name 3\\"/>
     </items>
@@ -341,7 +341,7 @@ exports[`xml generator for touch ui aem dialogs should print the touchUI dialog 
                      <element_0
     jcr:primaryType=\\"nt:unstructured\\"
     sling:resourceType=\\"granite/ui/components/coral/foundation/form/select\\"
-    name=\\"./dropdown\\" fieldLabel=\\"Mein Dropwdown\\"   fieldDescription=\\"Meine Beschreibung für Dropwdown\\" >
+    name=\\"./dropdown\\" fieldLabel=\\"Mein Dropdown\\"   fieldDescription=\\"Meine Beschreibung für Dropdown\\" >
     <items jcr:primaryType=\\"nt:unstructured\\">
         <option_0 jcr:primaryType=\\"nt:unstructured\\" value=\\"1\\" text=\\"Name 1\\"/><option_1 jcr:primaryType=\\"nt:unstructured\\" value=\\"2\\" text=\\"Name 2\\"/><option_2 jcr:primaryType=\\"nt:unstructured\\" value=\\"3\\" text=\\"Name 3\\"/>
     </items>

--- a/src/__tests___/results/touchUI/_cq_dialog/.content.xml
+++ b/src/__tests___/results/touchUI/_cq_dialog/.content.xml
@@ -46,7 +46,7 @@
 <element_5
     jcr:primaryType="nt:unstructured"
     sling:resourceType="granite/ui/components/coral/foundation/form/select"
-    name="./dropdown" fieldLabel="Mein Dropwdown"   fieldDescription="Meine Beschreibung für Dropwdown" >
+    name="./dropdown" fieldLabel="Mein Dropdown"   fieldDescription="Meine Beschreibung für Dropdown" >
     <items jcr:primaryType="nt:unstructured">
         <option_0 jcr:primaryType="nt:unstructured" value="1" text="Name 1"/><option_1 jcr:primaryType="nt:unstructured" value="2" text="Name 2"/><option_2 jcr:primaryType="nt:unstructured" value="3" text="Name 3"/>
     </items>
@@ -271,7 +271,7 @@
                      <element_0
     jcr:primaryType="nt:unstructured"
     sling:resourceType="granite/ui/components/coral/foundation/form/select"
-    name="./dropdown" fieldLabel="Mein Dropwdown"   fieldDescription="Meine Beschreibung für Dropwdown" >
+    name="./dropdown" fieldLabel="Mein Dropdown"   fieldDescription="Meine Beschreibung für Dropdown" >
     <items jcr:primaryType="nt:unstructured">
         <option_0 jcr:primaryType="nt:unstructured" value="1" text="Name 1"/><option_1 jcr:primaryType="nt:unstructured" value="2" text="Name 2"/><option_2 jcr:primaryType="nt:unstructured" value="3" text="Name 3"/>
     </items>

--- a/src/__tests___/xmlTouchUIGenerator.test.data.ts
+++ b/src/__tests___/xmlTouchUIGenerator.test.data.ts
@@ -2,102 +2,102 @@ import {
   TouchUIDialogFieldOptions,
   TouchUIDialogTab,
   TouchUIField,
-} from '../models';
-import { AEMTouchUIDialog } from './../models/AEMTouchUIDialogModels.model';
+} from "../models";
+import { AEMTouchUIDialog } from "./../models/AEMTouchUIDialogModels.model";
 
 const fields: TouchUIDialogFieldOptions[] = [
   {
-    label: 'Mein Textfeld',
+    label: "Mein Textfeld",
     type: TouchUIField.Text,
-    databaseName: 'label',
+    databaseName: "label",
     isRequired: true,
-    description: 'Meine Beschreibung für Textfeld...',
+    description: "Meine Beschreibung für Textfeld...",
   },
   {
-    label: 'Mein PathField',
+    label: "Mein PathField",
     type: TouchUIField.Path,
-    databaseName: 'path',
-    description: 'Meine Beschreibung für PathField...',
+    databaseName: "path",
+    description: "Meine Beschreibung für PathField...",
   },
   {
-    label: 'Mein Selectfeld',
+    label: "Mein Selectfeld",
     type: TouchUIField.Checkbox,
-    databaseName: 'select',
-    description: 'Meine Beschreibung für Select...',
+    databaseName: "select",
+    description: "Meine Beschreibung für Select...",
   },
   {
-    label: 'Mein Numberfield',
+    label: "Mein Numberfield",
     type: TouchUIField.Number,
-    databaseName: 'numbwr',
-    description: 'Meine Beschreibung für Numberfield...',
+    databaseName: "numbwr",
+    description: "Meine Beschreibung für Numberfield...",
     max: 50,
     min: 20,
   },
   {
-    label: 'Mein Imagefield',
+    label: "Mein Imagefield",
     type: TouchUIField.Imagefield,
-    databaseName: 'image',
-    description: 'Meine Beschreibung für Imagefield',
+    databaseName: "image",
+    description: "Meine Beschreibung für Imagefield",
     isRequired: true,
   },
   {
-    label: 'Mein Dropwdown',
-    type: TouchUIField.Dropwdown,
-    databaseName: 'dropdown',
-    description: 'Meine Beschreibung für Dropwdown',
+    label: "Mein Dropdown",
+    type: TouchUIField.Dropdown,
+    databaseName: "dropdown",
+    description: "Meine Beschreibung für Dropdown",
     options: [
-      { value: 1, name: 'Name 1' },
-      { value: 2, name: 'Name 2' },
-      { value: 3, name: 'Name 3' },
+      { value: 1, name: "Name 1" },
+      { value: 2, name: "Name 2" },
+      { value: 3, name: "Name 3" },
     ],
   },
   {
-    label: 'Meine Textarea',
+    label: "Meine Textarea",
     type: TouchUIField.TextArea,
-    databaseName: 'label',
-    description: 'Meine Beschreibung für Textarea...',
+    databaseName: "label",
+    description: "Meine Beschreibung für Textarea...",
     maxLength: 50,
   },
   {
-    label: 'Mein Richtexteld',
+    label: "Mein Richtexteld",
     type: TouchUIField.RichText,
-    databaseName: 'richtext',
-    description: 'Meine Beschreibung für Richtext...',
+    databaseName: "richtext",
+    description: "Meine Beschreibung für Richtext...",
   },
   {
-    label: 'Mein Button',
+    label: "Mein Button",
     type: TouchUIField.Button,
-    javaScriptHandler: 'alert(123)',
+    javaScriptHandler: "alert(123)",
   },
 ];
 
 const tabs: TouchUIDialogTab[] = [
-  { title: 'Mein erstes Tab', fields },
+  { title: "Mein erstes Tab", fields },
   {
-    title: 'Mein zweites Tab',
+    title: "Mein zweites Tab",
     fields: [
       {
-        label: 'Mein Touch UI Multifield',
+        label: "Mein Touch UI Multifield",
         type: TouchUIField.Multifield,
-        description: 'Meine Beschreibung für das Multifield...',
-        databaseName: 'multitouchuidatabase',
+        description: "Meine Beschreibung für das Multifield...",
+        databaseName: "multitouchuidatabase",
         multifieldtype: TouchUIField.Text,
       },
     ],
   },
   {
-    title: 'Mein drittes Tab',
+    title: "Mein drittes Tab",
     fields: [
       {
-        label: 'Nested Multifield',
-        databaseName: 'multi',
+        label: "Nested Multifield",
+        databaseName: "multi",
         type: TouchUIField.MultifieldNested,
         multifieldOptions: fields.slice(5),
       },
     ],
   },
   {
-    title: 'Mein viertes Tab',
+    title: "Mein viertes Tab",
     fields: [
       /* {
         label: 'Tag',
@@ -109,21 +109,21 @@ const tabs: TouchUIDialogTab[] = [
   },
 ];
 
-const ReactTemplate = './src/templates/react.template.html';
+const ReactTemplate = "./src/templates/react.template.html";
 export const exampleTouchUIDialog: AEMTouchUIDialog = {
   sightlyTemplate: ReactTemplate,
-  componentName: 'MyTestComponent',
-  componentGroup: 'MyTestGroup',
-  componentDescription: 'MyTestComponentDescription',
+  componentName: "MyTestComponent",
+  componentGroup: "MyTestGroup",
+  componentDescription: "MyTestComponentDescription",
   noDecoration: false,
   isContainer: false,
-  componentPath: './src/__tests___/results/touchUI',
-  tag: 'div',
-  css: 'sample-style',
+  componentPath: "./src/__tests___/results/touchUI",
+  tag: "div",
+  css: "sample-style",
   tabs,
   analytics: {
-    values: ['value1', 'value2'],
-    events: ['event1', 'event2'],
+    values: ["value1", "value2"],
+    events: ["event1", "event2"],
   },
-  resourceSuperType: 'core/wcm/components/text/v2/text',
+  resourceSuperType: "core/wcm/components/text/v2/text",
 };

--- a/src/__tests___/xmlTouchUIGenerator.test.data.ts
+++ b/src/__tests___/xmlTouchUIGenerator.test.data.ts
@@ -1,9 +1,9 @@
-import { AEMTouchUIDialog } from './../models/AEMTouchUIDialogModels.model';
 import {
   TouchUIDialogFieldOptions,
   TouchUIDialogTab,
-  TouchUIField
+  TouchUIField,
 } from '../models';
+import { AEMTouchUIDialog } from './../models/AEMTouchUIDialogModels.model';
 
 const fields: TouchUIDialogFieldOptions[] = [
   {
@@ -11,19 +11,19 @@ const fields: TouchUIDialogFieldOptions[] = [
     type: TouchUIField.Text,
     databaseName: 'label',
     isRequired: true,
-    description: 'Meine Beschreibung für Textfeld...'
+    description: 'Meine Beschreibung für Textfeld...',
   },
   {
     label: 'Mein PathField',
     type: TouchUIField.Path,
     databaseName: 'path',
-    description: 'Meine Beschreibung für PathField...'
+    description: 'Meine Beschreibung für PathField...',
   },
   {
     label: 'Mein Selectfeld',
     type: TouchUIField.Checkbox,
     databaseName: 'select',
-    description: 'Meine Beschreibung für Select...'
+    description: 'Meine Beschreibung für Select...',
   },
   {
     label: 'Mein Numberfield',
@@ -31,14 +31,14 @@ const fields: TouchUIDialogFieldOptions[] = [
     databaseName: 'numbwr',
     description: 'Meine Beschreibung für Numberfield...',
     max: 50,
-    min: 20
+    min: 20,
   },
   {
     label: 'Mein Imagefield',
     type: TouchUIField.Imagefield,
     databaseName: 'image',
     description: 'Meine Beschreibung für Imagefield',
-    isRequired: true
+    isRequired: true,
   },
   {
     label: 'Mein Dropwdown',
@@ -48,27 +48,27 @@ const fields: TouchUIDialogFieldOptions[] = [
     options: [
       { value: 1, name: 'Name 1' },
       { value: 2, name: 'Name 2' },
-      { value: 3, name: 'Name 3' }
-    ]
+      { value: 3, name: 'Name 3' },
+    ],
   },
   {
     label: 'Meine Textarea',
     type: TouchUIField.TextArea,
     databaseName: 'label',
     description: 'Meine Beschreibung für Textarea...',
-    maxLength: 50
+    maxLength: 50,
   },
   {
     label: 'Mein Richtexteld',
     type: TouchUIField.RichText,
     databaseName: 'richtext',
-    description: 'Meine Beschreibung für Richtext...'
+    description: 'Meine Beschreibung für Richtext...',
   },
   {
     label: 'Mein Button',
     type: TouchUIField.Button,
-    javaScriptHandler: 'alert(123)'
-  }
+    javaScriptHandler: 'alert(123)',
+  },
 ];
 
 const tabs: TouchUIDialogTab[] = [
@@ -81,9 +81,9 @@ const tabs: TouchUIDialogTab[] = [
         type: TouchUIField.Multifield,
         description: 'Meine Beschreibung für das Multifield...',
         databaseName: 'multitouchuidatabase',
-        multifieldtype: TouchUIField.Text
-      }
-    ]
+        multifieldtype: TouchUIField.Text,
+      },
+    ],
   },
   {
     title: 'Mein drittes Tab',
@@ -92,9 +92,9 @@ const tabs: TouchUIDialogTab[] = [
         label: 'Nested Multifield',
         databaseName: 'multi',
         type: TouchUIField.MultifieldNested,
-        multifieldOptions: fields.slice(5)
-      }
-    ]
+        multifieldOptions: fields.slice(5),
+      },
+    ],
   },
   {
     title: 'Mein viertes Tab',
@@ -105,8 +105,8 @@ const tabs: TouchUIDialogTab[] = [
         type: TouchUIField.Tag,
         description: 'Tolle Tags'
       } */
-    ]
-  }
+    ],
+  },
 ];
 
 const ReactTemplate = './src/templates/react.template.html';
@@ -123,7 +123,7 @@ export const exampleTouchUIDialog: AEMTouchUIDialog = {
   tabs,
   analytics: {
     values: ['value1', 'value2'],
-    events: ['event1', 'event2']
+    events: ['event1', 'event2'],
   },
-  resourceSuperType: 'core/wcm/components/text/v2/text'
+  resourceSuperType: 'core/wcm/components/text/v2/text',
 };

--- a/src/__tests___/xmlTouchUIGenerator.test.ts
+++ b/src/__tests___/xmlTouchUIGenerator.test.ts
@@ -1,6 +1,6 @@
+import * as fs from 'fs';
 import { AEMTouchUIDialog } from './../models/AEMTouchUIDialogModels.model';
 import { TouchUIXMLGenerator } from './../xmlTouchUIGenerator';
-import * as fs from 'fs';
 import { exampleTouchUIDialog } from './xmlTouchUIGenerator.test.data';
 
 describe('xml generator for touch ui aem dialogs', () => {
@@ -21,7 +21,7 @@ describe('xml generator for touch ui aem dialogs', () => {
   const externalReactAppTemplate =
     './src/templates/reactExternal.template.html';
 
-  [touchUIDialogPath, analyticsPath, configPath].forEach(file => {
+  [touchUIDialogPath, analyticsPath, configPath].forEach((file) => {
     try {
       fs.unlinkSync(file);
     } catch (e) {
@@ -76,13 +76,11 @@ describe('xml generator for touch ui aem dialogs', () => {
       componentGroup: 'External Group',
       componentDescription: '...',
       componentPath: externalReactAppPath,
-      tabs: []
+      tabs: [],
     };
     const touchUIGenerator = new TouchUIXMLGenerator(config);
     touchUIGenerator.writeFilesToAEM();
     const renderedFile = fs.readFileSync(externalreactPath).toString();
     expect(renderedFile).toMatchSnapshot();
   });
-
-
 });

--- a/src/models/AEMTouchUIDialogModels.model.ts
+++ b/src/models/AEMTouchUIDialogModels.model.ts
@@ -2,14 +2,14 @@
  * Please use index.ts to import and export the models out of model folder
  */
 
-import * as options from './TouchUIFieldOptions.model';
+import * as options from "./TouchUIFieldOptions.model";
 export type TouchUIDialogFieldOptions =
   | options.TextOptions
   | options.PathOptions
   | options.RichTextOptions
   | options.TextAreaOptions
   | options.CheckboxOptions
-  | options.DropwdownOptions
+  | options.DropdownOptions
   | options.NumberOptions
   | options.MultifieldOptions
   | options.ImagefieldOptions

--- a/src/models/AemEnumUI.model.ts
+++ b/src/models/AemEnumUI.model.ts
@@ -9,7 +9,7 @@ export enum FilePath {
   Text = 'templates/textfield.template.xml',
   RichText = 'templates/richtext.template.xml',
   Checkbox = 'templates/select.template.xml',
-  Dropwdown = 'templates/dropdown.template.xml',
+  Dropdown = 'templates/dropdown.template.xml',
   Number = 'templates/numberfield.template.xml',
   Multifield = 'templates/multifield.template.xml',
   Imagefield = 'templates/imagefield.template.xml',
@@ -22,7 +22,7 @@ export enum FilePath {
   MultifieldNested = 'templates/multifieldNested.template.xml',
   CqDesignDialog = 'templates/cqDesignDialog.template.xml',
   HtmlTag = 'templates/htmlTag.template.xml',
-  CqEditConfig = 'templates/cqEditConfig.template.xml'
+  CqEditConfig = 'templates/cqEditConfig.template.xml',
 }
 
 export enum PlaceHolder {
@@ -30,6 +30,7 @@ export enum PlaceHolder {
   Tab = '{{TABPLACEHOLDER}}',
   Element = 'ELNAME',
   Title = '{{TITLE}}',
+  Value = '{{VALUE}}',
   Fields = '{{FIELDS}}',
   Field = '{{FIELD}}',
   Database = '{{DATABASE}}',
@@ -53,5 +54,5 @@ export enum PlaceHolder {
   StyleSheets = '{{STYLES}}',
   JavaScript = '{{javascript}}',
   VariableName = '{{VAR}}',
-  Tariffspinner = '{{TARIFFSPINNER}}'
+  Tariffspinner = '{{TARIFFSPINNER}}',
 }

--- a/src/models/TouchUIFieldEnum.model.ts
+++ b/src/models/TouchUIFieldEnum.model.ts
@@ -3,15 +3,15 @@
  */
 
 export enum TouchUIField {
-  Path = 'pathfield',
-  Text = 'textfield',
-  RichText = 'richtext',
-  TextArea = 'textarea',
-  Checkbox = 'select',
-  Dropwdown = 'selection',
-  Number = 'numberfield',
-  Multifield = 'multifield',
-  Imagefield = 'imagefield',
-  Button = 'button',
-  MultifieldNested = 'multifieldNested',
+  Path = "pathfield",
+  Text = "textfield",
+  RichText = "richtext",
+  TextArea = "textarea",
+  Checkbox = "select",
+  Dropdown = "selection",
+  Number = "numberfield",
+  Multifield = "multifield",
+  Imagefield = "imagefield",
+  Button = "button",
+  MultifieldNested = "multifieldNested",
 }

--- a/src/models/TouchUIFieldOptions.model.ts
+++ b/src/models/TouchUIFieldOptions.model.ts
@@ -8,6 +8,7 @@ export interface CommonOptions {
   description?: string;
   isRequired?: boolean;
   label: string;
+  value?: string | boolean | number;
 }
 
 export interface BaseOptions extends CommonOptions {

--- a/src/models/TouchUIFieldOptions.model.ts
+++ b/src/models/TouchUIFieldOptions.model.ts
@@ -1,8 +1,8 @@
 /**
  * Please use index.ts to import and export the models out of the model folder
  */
-import { TouchUIDialogFieldOptions } from './AEMTouchUIDialogModels.model';
-import { TouchUIField } from './TouchUIFieldEnum.model';
+import { TouchUIDialogFieldOptions } from "./AEMTouchUIDialogModels.model";
+import { TouchUIField } from "./TouchUIFieldEnum.model";
 
 export interface CommonOptions {
   description?: string;
@@ -42,8 +42,8 @@ export interface CheckboxOptions extends BaseOptions {
   isDisabled?: boolean;
 }
 
-export interface DropwdownOptions extends BaseOptions {
-  type: TouchUIField.Dropwdown;
+export interface DropdownOptions extends BaseOptions {
+  type: TouchUIField.Dropdown;
   options: TouchUIFieldOption[];
 }
 

--- a/src/models/TouchUIFieldOptions.model.ts
+++ b/src/models/TouchUIFieldOptions.model.ts
@@ -8,7 +8,7 @@ export interface CommonOptions {
   description?: string;
   isRequired?: boolean;
   label: string;
-  value?: string | boolean | number;
+  defaultValue?: string | boolean | number;
 }
 
 export interface BaseOptions extends CommonOptions {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -2,27 +2,27 @@
  * Please use index.ts to import and export the models out of model folder
  */
 
+export { FilePath, PlaceHolder } from "./AemEnumUI.model";
 export {
-  TouchUIDialogFieldOptions,
   AEMTouchUIDialog,
-  TouchUIDialogTab,
+  Templates,
   TouchUIAnalytics,
-  Templates
-} from './AEMTouchUIDialogModels.model';
-export { FilePath, PlaceHolder } from './AemEnumUI.model';
-export { TouchUIField } from './TouchUIFieldEnum.model';
+  TouchUIDialogFieldOptions,
+  TouchUIDialogTab,
+} from "./AEMTouchUIDialogModels.model";
+export { CustomFilePath } from "./CustomAemEnumUI.model";
+export { TouchUIField } from "./TouchUIFieldEnum.model";
 export {
-  TouchUIFieldOption,
-  TextOptions,
+  ButtonOptions,
+  CheckboxOptions,
+  DropdownOptions,
+  ImagefieldOptions,
+  MultifieldNestedOptions,
+  MultifieldOptions,
+  NumberOptions,
   PathOptions,
   RichTextOptions,
   TextAreaOptions,
-  CheckboxOptions,
-  DropwdownOptions,
-  NumberOptions,
-  MultifieldOptions,
-  ImagefieldOptions,
-  ButtonOptions,
-  MultifieldNestedOptions
-} from './TouchUIFieldOptions.model';
-export { CustomFilePath } from './CustomAemEnumUI.model';
+  TextOptions,
+  TouchUIFieldOption,
+} from "./TouchUIFieldOptions.model";

--- a/src/uiGenerator.ts
+++ b/src/uiGenerator.ts
@@ -5,7 +5,7 @@ import {
   PlaceHolder,
   TouchUIDialogFieldOptions,
   TouchUIField,
-  TouchUIFieldOption
+  TouchUIFieldOption,
 } from './models';
 import { template } from './xmlTouchUITemplate';
 
@@ -42,7 +42,7 @@ export class UiGenerator {
    * in the getHtmlTag template and returns getHtmlTag template string
    */
   public getHtmlTag() {
-    console.log("????", template.htmlTag)
+    console.log('????', template.htmlTag);
     return template.htmlTag
       .replace(
         PlaceHolder.Tag,
@@ -152,6 +152,7 @@ export class UiGenerator {
         .replace(PlaceHolder.Element, 'element_' + i)
         .replace('/' + PlaceHolder.Element, '/element_' + i)
         .replace(PlaceHolder.Title, _field.label)
+        .replace(PlaceHolder.Value, this.getFieldValue(field))
         .replace(PlaceHolder.Database, `./${_field.databaseName}`)
         .replace(
           PlaceHolder.Description,
@@ -167,15 +168,20 @@ export class UiGenerator {
         )
     );
   }
+
+  public getFieldValue(field: TouchUIDialogFieldOptions): string {
+    return typeof field.value === 'undefined'
+      ? ''
+      : ` value="${this.parseFieldValue(field)}"`;
+  }
+
   /**
    * getOption() returns string element
    * @param  option: TouchUIFieldOption, i: number
    * @returns {string}
    */
   public getOption(option: TouchUIFieldOption, i: number) {
-    return `<option_${i} jcr:primaryType="nt:unstructured" value="${
-      option.value
-    }" text="${option.name}"/>`;
+    return `<option_${i} jcr:primaryType="nt:unstructured" value="${option.value}" text="${option.name}"/>`;
   }
   /**
    * getMultiField() returns the multifieldtype or FIELD-TYPE-ERROR
@@ -205,5 +211,18 @@ export class UiGenerator {
       return this.dialogConfig.sightlyTemplate;
     }
     return;
+  }
+
+  private parseFieldValue(field: TouchUIDialogFieldOptions): string {
+    switch (typeof field.value) {
+      case 'boolean':
+        return `{Boolean}${field.value ? 'true' : 'false'}`;
+      case 'number':
+        return `{Double}${field.value}`;
+      case 'string':
+        return field.value;
+      default:
+        return '';
+    }
   }
 }

--- a/src/uiGenerator.ts
+++ b/src/uiGenerator.ts
@@ -6,8 +6,8 @@ import {
   TouchUIDialogFieldOptions,
   TouchUIField,
   TouchUIFieldOption,
-} from './models';
-import { template } from './xmlTouchUITemplate';
+} from "./models";
+import { template } from "./xmlTouchUITemplate";
 
 export class UiGenerator {
   public dialogConfig: AEMTouchUIDialog;
@@ -42,15 +42,15 @@ export class UiGenerator {
    * in the getHtmlTag template and returns getHtmlTag template string
    */
   public getHtmlTag() {
-    console.log('????', template.htmlTag);
+    console.log("????", template.htmlTag);
     return template.htmlTag
       .replace(
         PlaceHolder.Tag,
-        this.dialogConfig.tag ? this.dialogConfig.tag : 'div'
+        this.dialogConfig.tag ? this.dialogConfig.tag : "div"
       )
       .replace(
         PlaceHolder.Class,
-        this.dialogConfig.css ? this.dialogConfig.css : ''
+        this.dialogConfig.css ? this.dialogConfig.css : ""
       );
   }
   /**
@@ -61,17 +61,17 @@ export class UiGenerator {
     return this.dialogConfig.tabs
       .map((tab, index) => {
         return template.tab
-          .replace(PlaceHolder.Element, 'tab_' + index)
-          .replace('/' + PlaceHolder.Element, '/tab_' + index)
+          .replace(PlaceHolder.Element, "tab_" + index)
+          .replace("/" + PlaceHolder.Element, "/tab_" + index)
           .replace(PlaceHolder.Title, tab.title)
           .replace(
             PlaceHolder.Fields,
             tab.fields
               .map((field, fieldIndex) => this.getField(field, fieldIndex))
-              .join('')
+              .join("")
           );
       })
-      .join('');
+      .join("");
   }
 
   /**
@@ -86,14 +86,14 @@ export class UiGenerator {
         return template.pathfield;
       case TouchUIField.Checkbox:
         return template.select;
-      case TouchUIField.Dropwdown:
+      case TouchUIField.Dropdown:
         return template.dropdown.replace(
           PlaceHolder.Options,
           field.options
             ? field.options
                 .map((option, i) => this.getOption(option, i))
-                .join('')
-            : 'OPTIONERROR'
+                .join("")
+            : "OPTIONERROR"
         );
       case TouchUIField.Multifield:
         return template.multiField.replace(
@@ -115,13 +115,13 @@ export class UiGenerator {
       case TouchUIField.Button:
         return template.button.replace(
           PlaceHolder.JavaScript,
-          field.javaScriptHandler || ''
+          field.javaScriptHandler || ""
         );
       default:
         // text, bumber, error
         return template.textfield.replace(
-          'textfield',
-          field.type || 'FIELDERROR'
+          "textfield",
+          field.type || "FIELDERROR"
         );
     }
   }
@@ -141,22 +141,22 @@ export class UiGenerator {
         .replace(PlaceHolder.Common, template.commonField)
         .replace(
           PlaceHolder.MaxLength,
-          _field.maxLength ? ` maxlength="${_field.maxLength}" ` : ''
+          _field.maxLength ? ` maxlength="${_field.maxLength}" ` : ""
         )
-        .replace(PlaceHolder.Max, _field.max ? ` max="${_field.max}" ` : '')
-        .replace(PlaceHolder.Min, _field.min ? ` min="${_field.min}" ` : '')
+        .replace(PlaceHolder.Max, _field.max ? ` max="${_field.max}" ` : "")
+        .replace(PlaceHolder.Min, _field.min ? ` min="${_field.min}" ` : "")
         .replace(
           PlaceHolder.Required,
-          _field.isRequired ? ` required="{Boolean}true" ` : ''
+          _field.isRequired ? ` required="{Boolean}true" ` : ""
         )
-        .replace(PlaceHolder.Element, 'element_' + i)
-        .replace('/' + PlaceHolder.Element, '/element_' + i)
+        .replace(PlaceHolder.Element, "element_" + i)
+        .replace("/" + PlaceHolder.Element, "/element_" + i)
         .replace(PlaceHolder.Title, _field.label)
         .replace(PlaceHolder.Value, this.getFieldValue(field))
         .replace(PlaceHolder.Database, `./${_field.databaseName}`)
         .replace(
           PlaceHolder.Description,
-          _field.description ? ` fieldDescription="${_field.description}"` : ''
+          _field.description ? ` fieldDescription="${_field.description}"` : ""
         )
         /**
          * not used anymore
@@ -164,14 +164,14 @@ export class UiGenerator {
          */
         .replace(
           PlaceHolder.isDisabled,
-          _field.isDisabled ? ` disabled="{Boolean}true" ` : ''
+          _field.isDisabled ? ` disabled="{Boolean}true" ` : ""
         )
     );
   }
 
   public getFieldValue(field: TouchUIDialogFieldOptions): string {
-    return typeof field.value === 'undefined'
-      ? ''
+    return typeof field.value === "undefined"
+      ? ""
       : ` value="${this.parseFieldValue(field)}"`;
   }
 
@@ -189,7 +189,7 @@ export class UiGenerator {
    * @returns {string}
    */
   public getMultiField(field: MultifieldOptions) {
-    return field.multifieldtype ? field.multifieldtype : 'FIELD-TYPE-ERROR';
+    return field.multifieldtype ? field.multifieldtype : "FIELD-TYPE-ERROR";
   }
   /**
    * getMultiFieldNested() calls  getField and returns the field string template
@@ -199,7 +199,7 @@ export class UiGenerator {
   public getMultiFieldNested(field: MultifieldNestedOptions) {
     return (field.multifieldOptions || [])
       .map((fieldOption, index) => this.getField(fieldOption, index))
-      .join('');
+      .join("");
   }
   /**
    * getSightlyTemplate() creates the sightly Template file if we have sightlyTemplate
@@ -215,14 +215,14 @@ export class UiGenerator {
 
   private parseFieldValue(field: TouchUIDialogFieldOptions): string {
     switch (typeof field.value) {
-      case 'boolean':
-        return `{Boolean}${field.value ? 'true' : 'false'}`;
-      case 'number':
+      case "boolean":
+        return `{Boolean}${field.value ? "true" : "false"}`;
+      case "number":
         return `{Double}${field.value}`;
-      case 'string':
+      case "string":
         return field.value;
       default:
-        return '';
+        return "";
     }
   }
 }

--- a/src/uiGenerator.ts
+++ b/src/uiGenerator.ts
@@ -170,7 +170,7 @@ export class UiGenerator {
   }
 
   public getFieldValue(field: TouchUIDialogFieldOptions): string {
-    return typeof field.value === "undefined"
+    return typeof field.defaultValue === "undefined"
       ? ""
       : ` value="${this.parseFieldValue(field)}"`;
   }
@@ -214,13 +214,13 @@ export class UiGenerator {
   }
 
   private parseFieldValue(field: TouchUIDialogFieldOptions): string {
-    switch (typeof field.value) {
+    switch (typeof field.defaultValue) {
       case "boolean":
-        return `{Boolean}${field.value ? "true" : "false"}`;
+        return `{Boolean}${field.defaultValue ? "true" : "false"}`;
       case "number":
-        return `{Double}${field.value}`;
+        return `{Double}${field.defaultValue}`;
       case "string":
-        return field.value;
+        return field.defaultValue;
       default:
         return "";
     }

--- a/src/xmlTouchUIGenerator.ts
+++ b/src/xmlTouchUIGenerator.ts
@@ -5,11 +5,8 @@ import { UiGenerator } from './uiGenerator';
 import { template } from './xmlTouchUITemplate';
 
 export class TouchUIXMLGenerator extends UiGenerator {
-  public dialogConfig: AEMTouchUIDialog;
-
   constructor(dialogConfig: AEMTouchUIDialog) {
     super(dialogConfig);
-    this.dialogConfig = dialogConfig;
   }
 
   /**
@@ -22,17 +19,17 @@ export class TouchUIXMLGenerator extends UiGenerator {
     return !this.dialogConfig.analytics
       ? null
       : template.tracking
-        .replace(PlaceHolder.Title, this.dialogConfig.componentName)
-        .replace(PlaceHolder.Group, this.dialogConfig.componentGroup)
-        .replace(
-          PlaceHolder.TrackingEvents,
-          this.getAnalyticsElements('events')
-        )
-        .replace(
-          PlaceHolder.TrackingVars,
-          this.getAnalyticsElements('values')
-        )
-        .replace(PlaceHolder.Group, this.dialogConfig.componentGroup);
+          .replace(PlaceHolder.Title, this.dialogConfig.componentName)
+          .replace(PlaceHolder.Group, this.dialogConfig.componentGroup)
+          .replace(
+            PlaceHolder.TrackingEvents,
+            this.getAnalyticsElements('events')
+          )
+          .replace(
+            PlaceHolder.TrackingVars,
+            this.getAnalyticsElements('values')
+          )
+          .replace(PlaceHolder.Group, this.dialogConfig.componentGroup);
   }
 
   /**
@@ -45,11 +42,11 @@ export class TouchUIXMLGenerator extends UiGenerator {
     template.component = !this.dialogConfig.resourceSuperType
       ? template.component.replace(PlaceHolder.ResourceSuperType, '')
       : (template.component = template.component.replace(
-        PlaceHolder.ResourceSuperType,
-        'sling:resourceSuperType="' +
-        this.dialogConfig.resourceSuperType +
-        '"'
-      ));
+          PlaceHolder.ResourceSuperType,
+          'sling:resourceSuperType="' +
+            this.dialogConfig.resourceSuperType +
+            '"'
+        ));
 
     return template.component
       .replace(PlaceHolder.Title, this.dialogConfig.componentName)
@@ -61,11 +58,11 @@ export class TouchUIXMLGenerator extends UiGenerator {
       .replace(
         PlaceHolder.NoDecoration,
         '{Boolean}' +
-        String(
-          this.dialogConfig.noDecoration
-            ? this.dialogConfig.noDecoration
-            : false
-        )
+          String(
+            this.dialogConfig.noDecoration
+              ? this.dialogConfig.noDecoration
+              : false
+          )
       )
       .replace(
         PlaceHolder.IsContainer,
@@ -147,7 +144,7 @@ export class TouchUIXMLGenerator extends UiGenerator {
     // first folder
     let currentFolder = path.resolve(folderPath.split('/')[0]);
     // create folder if it does not exist
-    folderPath.split('/').forEach(folder => {
+    folderPath.split('/').forEach((folder) => {
       currentFolder += '/' + folder;
       if (!fs.existsSync(path.resolve(currentFolder))) {
         fs.mkdirSync(path.resolve(currentFolder));
@@ -242,7 +239,7 @@ export class TouchUIXMLGenerator extends UiGenerator {
    */
   public writeSightlyTemplate() {
     if (!this.getSightlyTemplate()) {
-      console.log("No Sightly Template", this.dialogConfig.componentName);
+      console.log('No Sightly Template', this.dialogConfig.componentName);
       return;
     }
     const file = this.dialogConfig.componentPath.split('/')[

--- a/src/xmlTouchUITemplate.ts
+++ b/src/xmlTouchUITemplate.ts
@@ -1,14 +1,14 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import { FilePath } from './models';
-const Template = require('./dialogGeneratorConfig');
-import('./dialogGeneratorConfig');
+import * as fs from "fs";
+import * as path from "path";
+import { FilePath } from "./models";
+const Template = require("./dialogGeneratorConfig");
+import("./dialogGeneratorConfig");
 export const getFile = (filePath: string) => {
   return fs.readFileSync(filePath).toString();
 };
 
 const CommonField =
-  'name="{{DATABASE}}" fieldLabel="{{TITLE}}" {{REQUIRED}} {{DESC}} {{DISABLED}}';
+  'name="{{DATABASE}}" fieldLabel="{{TITLE}}"{{VALUE}} {{REQUIRED}} {{DESC}} {{DISABLED}}';
 
 // here we may get costum template path or we use the defuelt template
 export const template = {
@@ -33,7 +33,7 @@ export const template = {
     Template.checkboxTemplate || path.resolve(__dirname, FilePath.Checkbox)
   ),
   dropdown: getFile(
-    Template.dropdownTemplate || path.resolve(__dirname, FilePath.Dropwdown)
+    Template.dropdownTemplate || path.resolve(__dirname, FilePath.Dropdown)
   ),
   multiField: getFile(
     Template.multifieldTemplate || path.resolve(__dirname, FilePath.Multifield)
@@ -65,5 +65,5 @@ export const template = {
   cqDesignDialog: getFile(
     Template.cqDesignDialogTemplate ||
       path.resolve(__dirname, FilePath.CqDesignDialog)
-  )
+  ),
 };

--- a/src/xmlTouchUITemplate.ts
+++ b/src/xmlTouchUITemplate.ts
@@ -1,8 +1,8 @@
-import * as fs from "fs";
-import * as path from "path";
-import { FilePath } from "./models";
-const Template = require("./dialogGeneratorConfig");
-import("./dialogGeneratorConfig");
+import * as fs from 'fs';
+import * as path from 'path';
+import { FilePath } from './models';
+const Template = require('./dialogGeneratorConfig');
+import('./dialogGeneratorConfig');
 export const getFile = (filePath: string) => {
   return fs.readFileSync(filePath).toString();
 };


### PR DESCRIPTION
This is a useful library for a project I am working on but I quickly realised that it would be really useful to be able to set the value attribute for dialog xml.  

I've therefore added a defaultValue property to `CommonOptions` and some code to set the attribute if provided.  It could potentially be improved upon as far as the type strictness goes for the field options but I thought that I would shoot a PR and see what people think.  I've tested these changes in an AEM app and as far as I can see they behave as one would expect.

I also noticed an existing typo for `TouchUIField.Dropwdown` and have corrected it.  