### PR TITLE
Fix builder.js not running on windows

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -34,7 +34,7 @@ files.forEach(file => {
     // execute each file
     console.log('Run dialog file: ' + file)
     // run the typescript file
-    exec('ts-node --compiler-options \'{"module": "commonjs"}\' ' + file, (err, t) => {
-        console.log(err || t)
+    exec('ts-node --compilerOptions {\"\"\"module\"\"\":\"\"\"commonjs\"\"\"} ' + file, (err, t) => {
+        console.log(err || t)
     })
 })

--- a/src/builder.js
+++ b/src/builder.js
@@ -32,9 +32,15 @@ function addFiles(dirPath) {
 
 files.forEach(file => {
     // execute each file
-    console.log('Run dialog file: ' + file)
+    console.log('Run dialog file: ' + file);
     // run the typescript file
-    exec('ts-node --compilerOptions {\"\"\"module\"\"\":\"\"\"commonjs\"\"\"} ' + file, (err, t) => {
-        console.log(err || t)
-    })
-})
+    if (process.platform === 'win32') {
+        exec('ts-node --compilerOptions {\"\"\"module\"\"\":\"\"\"commonjs\"\"\"} ' + file, (err, t) => {
+            console.log(err || t)
+        });
+    } else {
+        exec('ts-node --compiler-options \'{"module": "commonjs"}\' ' + file, (err, t) => {
+            console.log(err || t)
+        });
+    }
+});


### PR DESCRIPTION
When running build on a windows machine, it fails for every file due to unexpected inputs `'`

This fixes that error, I've wrapped it around a platform check so that other platforms will continue to work as they currently do.